### PR TITLE
Thymeleafを使った情報削除(DELETE)処理の実装

### DIFF
--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -16,5 +16,5 @@ public class Student {
   private int age;
   private String gender;
   private String remark;
-  private boolean is_deleted;
+  private boolean isDeleted;
 }

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -6,7 +6,6 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
-import org.springframework.stereotype.Repository;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentsCourses;
 
@@ -33,7 +32,7 @@ public interface StudentRepository {
    * 新しい受講生情報をデータベースに保存します。
    * @param student 保存する受講生情報
    */
-  @Insert("INSERT INTO students(name, furigana, nickname, email, city, age, gender, remark, is_deleted)"
+  @Insert("INSERT INTO students(name, furigana, nickname, email, city, age, gender, remark, isDeleted)"
       + "VALUES(#{name}, #{furigana}, #{nickname}, #{email}, #{city}, #{age}, #{gender}, #{remark}, false)")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void registerStudent(Student student);
@@ -44,7 +43,7 @@ public interface StudentRepository {
   void registerStudentsCourses(StudentsCourses studentsCourses);
 
   @Update("UPDATE students SET name = #{name}, furigana = #{furigana}, nickname = #{nickname}, "
-      + "email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark}, is_deleted = #{is_deleted} WHERE id = #{id}")
+      + "email = #{email}, city = #{city}, age = #{age}, gender = #{gender}, remark = #{remark}, isDeleted = #{isDeleted} WHERE id = #{id}")
   void updateStudent(Student student);
 
   @Update("UPDATE students_courses SET course_name = #{courseName} WHERE id = #{id}")

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -18,6 +18,7 @@
     <th>年齢</th>
     <th>性別</th>
     <th>備考</th>
+    <th>キャンセル</th>
   </tr>
   </thead>
   <tbody>
@@ -34,6 +35,9 @@
     <td th:text="${studentDetail.student.age}">20</td>
     <td th:text="${studentDetail.student.gender}">男性</td>
     <td th:text="${studentDetail.student.remark}">特になし</td>
+    <td>
+      <input type="checkbox" th:checked="${studentDetail.student.isDeleted}" />
+    </td>
   </tr>
   </tbody>
 </table>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -47,9 +47,13 @@
     <label for="remark">備考</label>
     <textarea id="remark" th:field="*{student.remark}"></textarea>
   </div>
+  <div>
+    <label for="isDeleted">キャンセル</label>
+    <input type="checkbox" id="isDeleted" th:field="*{student.deleted}"/>
+  </div>
   <div th:each="course, stat : *{studentsCourses}">
-    <label for="id" th:for="studentCourse.__${stat.index}__].id">受講コースID：</label>
-    <input type="text" id="id" th:id="studentCourse.__${stat.index}__].id"
+    <label for="studentCourseId" th:for="studentCourse.__${stat.index}__].id">受講コースID：</label>
+    <input type="text" id="studentCourseId" th:id="studentCourse.__${stat.index}__].id"
            th:field="*{studentsCourses[__${stat.index}__].id}" />
     <label for="courseName" th:for="studentCourse.__${stat.index}__].courseName">受講コース名：</label>
     <input type="text" id="courseName" th:id="studentCourse.__${stat.index}__].courseName"


### PR DESCRIPTION
### 第30回の課題（受講生情報削除処理の実装）を以下のとおり実施いたしました。

## 概要
キャンセルのチェックボックスを追加し、受講生一覧のリンクから受講生更新フォームに遷移し、フォームでキャンセルにチェックを入れられるようにしました。 
更新後は、自動的に受講生情報の一覧が表示され、更新された受講生情報を確認できます。

## 動作確認
①パスとして「/studentList」を指定すると、ブラウザに受講生情報の一覧が表示されます。 
キャンセルのチェックボックスが追加されていることを確認できます。 
![スクリーンショット 2024-10-11 113213](https://github.com/user-attachments/assets/fa24346a-52a5-43fe-bc33-ffdfe8b5e4c1)

②「名前」はリンクになっており、クリックすると受講生の更新フォームに遷移します。 
![スクリーンショット 2024-10-11 113230](https://github.com/user-attachments/assets/db9a1e4f-b56b-479b-beca-010e0cad2e59)

③ここで、キャンセルにチェックを入れて、更新ボタンを押すと、自動的に再度受講生情報の一覧が表示され、更新された受講生情報を確認できます。
![スクリーンショット 2024-10-11 113242](https://github.com/user-attachments/assets/2942d506-eb3b-43f3-9cb1-f3847c7f27b8)

④DBのテーブルのデータを確認
![スクリーンショット 2024-10-11 113300](https://github.com/user-attachments/assets/e0ac58af-40ed-4b99-afcf-999f933fc0a0)


