### PR TITLE
StudentConverterTestの実装

### DIFF
--- a/src/test/java/raisetech/student/management/controller/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/student/management/controller/converter/StudentConverterTest.java
@@ -1,0 +1,76 @@
+package raisetech.student.management.controller.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import raisetech.student.management.data.Student;
+import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.domain.StudentDetail;
+
+class StudentConverterTest {
+
+  private StudentConverter sut;
+
+  @BeforeEach
+  void before() {
+    sut = new StudentConverter();
+  }
+
+  @Test
+  void 受講生のリストと受講生コース情報のリストを渡して受講生詳細のリストが作成できること() {
+    Student student = createStudent();
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setId(1);
+    studentCourse.setStudentId("1");
+    studentCourse.setCourseName("Javaコース");
+    studentCourse.setStartDate(LocalDateTime.now());
+    studentCourse.setEndDate(LocalDateTime.now().plusYears(1));
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    List<StudentDetail> actual = sut.convertStudentDetails(studentList, studentCourseList);
+
+    assertThat(actual.get(0).getStudent()).isEqualTo(student);
+    assertThat(actual.get(0).getStudentCourseList()).isEqualTo(studentCourseList);
+  }
+
+  @Test
+  void 受講生のリストと受講生コース情報のリストを渡した時に紐づかない受講生コース情報は除外されること() {
+    Student student = createStudent();
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setId(1);
+    studentCourse.setStudentId("2");
+    studentCourse.setCourseName("Javaコース");
+    studentCourse.setStartDate(LocalDateTime.now());
+    studentCourse.setEndDate(LocalDateTime.now().plusYears(1));
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    List<StudentDetail> actual = sut.convertStudentDetails(studentList, studentCourseList);
+
+    assertThat(actual.get(0).getStudent()).isEqualTo(student);
+    assertThat(actual.get(0).getStudentCourseList()).isEmpty();
+  }
+
+  private static Student createStudent() {
+    Student student = new Student();
+    student.setId("1");
+    student.setName("長井　アンナ");
+    student.setFurigana("ナガイ　アンナ");
+    student.setNickname("あんちゃん");
+    student.setEmail("test@example.com");
+    student.setCity("大阪");
+    student.setAge(34);
+    student.setGender("femail");
+    student.setRemark("大阪大好き");
+    student.setDeleted(false);
+    return student;
+  }
+}


### PR DESCRIPTION
## 概要
`StudentConverter`　クラスのテストコードを実装しました。
このテストでは、受講生と受講生コース情報を元に、受講生詳細リストを正しく生成できるか、また意図しないデータが含まれないかを確認しています。

### 実装内容
以下の2つのテストケースを追加しました：

1. **受講生詳細リストの生成**
   - **目的**: 受講生リストと受講生コース情報リストを引数として渡した際、`StudentConverter`クラスが正しい受講生詳細リストを生成できることを確認します。
   - **内容**: 受講生と受講生コース情報が正しく対応付けられ、意図した構造の詳細リストが出力されるかどうかをチェックします。

2. **紐づかない受講生コース情報の除外**
   - **目的**: 受講生リストと受講生コース情報リストを渡した際、紐づかない受講生コース情報が出力結果に含まれないことを確認します。
   - **内容**: `StudentConverter`クラスが、受講生に関連付けられていない受講生コース情報を除外するように動作しているかを確認します。

### テスト結果
すべてのテストケースが意図した通りに成功しており、`StudentConverter`クラスの正確な動作を確認しました。
この実装により、受講生とそのコース情報の適切な紐づけが行われていることが保証され、無関係なデータが結果に含まれないようになっています。
![スクリーンショット 2024-11-01 103144](https://github.com/user-attachments/assets/5875e988-030b-4f2e-b827-fce3d80f81da)
![スクリーンショット 2024-11-01 103211](https://github.com/user-attachments/assets/df91025d-e410-44b6-b0b6-e079f422a073)

