### PR TITLE
条件検索機能の実装

### DIFF
--- a/src/main/java/raisetech/student/management/Application.java
+++ b/src/main/java/raisetech/student/management/Application.java
@@ -2,10 +2,8 @@ package raisetech.student.management;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
-import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @OpenAPIDefinition(info = @Info(title = "受講生管理システム"))
 @SpringBootApplication

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -5,8 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import java.util.List;
 import org.apache.ibatis.javassist.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -119,6 +117,31 @@ public class StudentController {
     } else {
       return ResponseEntity.ok(courses);
     }
+  }
+
+  /**
+   * 条件に基づいて受講生の詳細情報を検索します。
+   * @param name 名前
+   * @param furigana フリガナ
+   * @param city 居住地域
+   * @param age 年齢
+   * @param gender 性別
+   * @param courseName コース名
+   * @param status コースステータス
+   * @return 統合された受講生の詳細情報
+   */
+  @Operation(summary = "条件検索による受講生の詳細取得", description = "条件に合致する受講生とそのコース情報を統合して取得します。")
+  @GetMapping("/students/search")
+  public List<IntegratedDetail> searchStudents(
+      @RequestParam(required = false) String name,
+      @RequestParam(required = false) String furigana,
+      @RequestParam(required = false) String city,
+      @RequestParam(required = false) Integer age,
+      @RequestParam(required = false) String gender,
+      @RequestParam(required = false) String courseName,
+      @RequestParam(required = false) CourseStatus.Status status
+  ) {
+    return service.searchIntegratedDetails(name, furigana, city, age, gender, courseName, status);
   }
 
   /**

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.student.management.data.CourseStatus;
 import raisetech.student.management.domain.CourseDetail;
-import raisetech.student.management.domain.IntegratedDetail;
+import raisetech.student.management.domain.StudentSearchResponse;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.service.StudentService;
 
@@ -104,7 +104,7 @@ public class StudentController {
       responses = {
           @ApiResponse(responseCode = "200", description = "検索成功",
               content = @Content(mediaType = "application/json",
-                  schema = @Schema(implementation = IntegratedDetail.class))),
+                  schema = @Schema(implementation = StudentSearchResponse.class))),
           @ApiResponse(responseCode = "204", description = "データなし"),
           @ApiResponse(responseCode = "500", description = "サーバーエラー",
               content = @Content)}
@@ -131,8 +131,8 @@ public class StudentController {
    * @return 統合された受講生の詳細情報
    */
   @Operation(summary = "条件検索による受講生の詳細取得", description = "条件に合致する受講生とそのコース情報を統合して取得します。")
-  @GetMapping("/students/search")
-  public List<IntegratedDetail> searchStudents(
+  @GetMapping("/students")
+  public List<StudentSearchResponse> searchStudents(
       @RequestParam(required = false) String name,
       @RequestParam(required = false) String furigana,
       @RequestParam(required = false) String city,
@@ -162,9 +162,9 @@ public class StudentController {
           @ApiResponse(responseCode = "500", description = "サーバーエラー",
               content = @Content)})
   @PostMapping("/registerStudent")
-  public ResponseEntity<IntegratedDetail> registerStudent(
+  public ResponseEntity<StudentSearchResponse> registerStudent(
       @RequestBody @Valid StudentDetail studentDetail) {
-    IntegratedDetail responseStudentDetail = service.registerStudent(studentDetail);
+    StudentSearchResponse responseStudentDetail = service.registerStudent(studentDetail);
     return ResponseEntity.ok(responseStudentDetail);
   }
 

--- a/src/main/java/raisetech/student/management/domain/StudentSearchResponse.java
+++ b/src/main/java/raisetech/student/management/domain/StudentSearchResponse.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class IntegratedDetail {
+public class StudentSearchResponse {
 
   @Valid
   private StudentDetail studentDetail;

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -2,11 +2,11 @@ package raisetech.student.management.repository;
 
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 import raisetech.student.management.data.CourseStatus;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
-import raisetech.student.management.service.StudentService;
 
 /**
  *受講生テーブルと受講生コース情報テーブルと紐づくRepositoryです。
@@ -52,6 +52,37 @@ public interface StudentRepository {
    * @return 受講生コースIDに紐づく受講生コース申込状況
    */
   CourseStatus searchCourseStatus(int courseId);
+
+  /**
+   * 条件に基づいて受講生を検索します。
+   * @param name 名前
+   * @param furigana フリガナ
+   * @param city 居住地域
+   * @param age 年齢
+   * @param gender 性別
+   * @return 受講生のリスト
+   */
+  List<Student> findStudentsByConditions(
+      @Param("name") String name,
+      @Param("furigana") String furigana,
+      @Param("city") String city,
+      @Param("age") Integer age,
+      @Param("gender") String gender
+  );
+
+  /**
+   * 条件に基づいて受講生コースを検索します。
+   * @param courseName コース名
+   * @return 受講生コースのリスト
+   */
+  List<StudentCourse> findCoursesByConditions(@Param("courseName") String courseName);
+
+  /**
+   * 条件に基づいて申込状況を検索します。
+   * @param status コースステータス
+   * @return コースステータスのリスト
+   */
+  List<CourseStatus> findCourseStatusByConditions(@Param("status") CourseStatus.Status status);
 
   /**
    * 受講生とそのコースの詳細およびステータス情報を検索します。

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -14,7 +14,7 @@ import raisetech.student.management.data.CourseStatus;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
 import raisetech.student.management.domain.CourseDetail;
-import raisetech.student.management.domain.IntegratedDetail;
+import raisetech.student.management.domain.StudentSearchResponse;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.repository.StudentRepository;
 
@@ -92,7 +92,7 @@ public class StudentService {
    * @param status     コース申込状況。条件に一致する申込状況を検索します（"仮申込"、"本申込"、"受講中"、"受講終了"）。
    * @return 条件に一致する受講生およびそのコース詳細を統合した詳細情報のリスト。 統合された詳細は、受講生情報とそのコース情報が含まれます。
    */
-  public List<IntegratedDetail> searchIntegratedDetails(String name, String furigana, String city,
+  public List<StudentSearchResponse> searchIntegratedDetails(String name, String furigana, String city,
       Integer age, String gender, String courseName, CourseStatus.Status status) {
     // 条件に一致する受講生を検索
     List<Student> students = repository.findStudentsByConditions(name, furigana, city, age, gender);
@@ -111,7 +111,7 @@ public class StudentService {
           List<StudentCourse> courses = detail.getStudentCourseList();
           List<CourseDetail> courseDetails = courseConverter.convertToCourseDetails(courses,
               courseStatuses);
-          return new IntegratedDetail(detail, courseDetails);
+          return new StudentSearchResponse(detail, courseDetails);
         })
         .collect(Collectors.toList());
   }
@@ -123,7 +123,7 @@ public class StudentService {
    * @return 登録情報を付与した受講生詳細
    */
   @Transactional
-  public IntegratedDetail registerStudent(StudentDetail studentDetail) {
+  public StudentSearchResponse registerStudent(StudentDetail studentDetail) {
     Student student = studentDetail.getStudent();
     repository.updateStudent(student);
 
@@ -145,7 +145,7 @@ public class StudentService {
       courseDetails.add(courseDetail);
     });
 
-    return new IntegratedDetail(studentDetail, courseDetails);
+    return new StudentSearchResponse(studentDetail, courseDetails);
   }
 
 

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -35,6 +35,45 @@
     SELECT * FROM course_status
   </select>
 
+  <!-- 受講生条件検索 -->
+  <select id="findStudentsByConditions" resultType="raisetech.student.management.data.Student">
+    SELECT * FROM students
+    WHERE 1=1
+    <if test="name != null and name != ''">
+      AND name LIKE CONCAT('%', #{name}, '%')
+    </if>
+    <if test="furigana != null and furigana != ''">
+      AND furigana LIKE CONCAT('%', #{furigana}, '%')
+    </if>
+    <if test="city != null and city != ''">
+      AND city LIKE CONCAT('%', #{city}, '%')
+    </if>
+    <if test="age != null">
+      AND age = #{age}
+    </if>
+    <if test="gender != null and gender != ''">
+      AND gender = #{gender}
+    </if>
+  </select>
+
+  <!-- 受講生コース条件検索 -->
+  <select id="findCoursesByConditions" resultType="raisetech.student.management.data.StudentCourse">
+    SELECT * FROM students_courses
+    WHERE 1=1
+    <if test="courseName != null and courseName != ''">
+      AND course_name = #{courseName}
+    </if>
+  </select>
+
+  <!-- 申込状況条件検索 -->
+  <select id="findCourseStatusByConditions" resultType="raisetech.student.management.data.CourseStatus">
+    SELECT * FROM course_status
+    WHERE 1=1
+    <if test="status != null">
+      AND status = #{status}
+    </if>
+  </select>
+
   <!-- 受講生とそのコースの詳細およびステータス情報を検索 -->
   <select id="searchStudentsWithStatus" parameterType="map" resultType="raisetech.student.management.data.StudentCourse">
     SELECT sc.*, cs.status

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -33,11 +32,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import raisetech.student.management.data.CourseStatus;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
 import raisetech.student.management.domain.CourseDetail;
+import raisetech.student.management.domain.IntegratedDetail;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.service.StudentService;
 
@@ -99,6 +98,41 @@ class StudentControllerTest {
     verify(service, times(1)).getAllCourses();
   }
 
+
+  @Test
+  void 条件に基づいて受講生詳細を検索し正しいデータが返ってくること() throws Exception {
+    // モックデータを直接フィールドに設定
+    IntegratedDetail detail = new IntegratedDetail() {
+      public String name = "テスト花子";
+      public String city = "東京";
+      public int age = 25;
+      public String gender = "女性";
+      public String courseName = "Java";
+      public CourseStatus.Status status = CourseStatus.Status.仮申込;
+    };
+
+    // モックサービスの設定
+    when(service.searchIntegratedDetails(
+        "テスト花子", "テストハナコ", "東京", 25, "女性", "Java", null))
+        .thenReturn(List.of(detail));
+
+    // テストの実行
+    mockMvc.perform(get("/students/search")
+            .param("name", "テスト花子")
+            .param("furigana", "テストハナコ")
+            .param("city", "東京")
+            .param("age", "25")
+            .param("gender", "女性")
+            .param("courseName", "Java"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].name").value("テスト花子"))
+        .andExpect(jsonPath("$[0].city").value("東京"))
+        .andExpect(jsonPath("$[0].age").value(25))
+        .andExpect(jsonPath("$[0].gender").value("女性"))
+        .andExpect(jsonPath("$.length()").value(1))  // Corrected the path here
+        .andExpect(jsonPath("$[0].courseName").value("Java"));
+  }
 
   @Test
   void 受講生コース詳細の一覧検索が実行できてコースが返ってくること() throws Exception {

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -36,7 +36,7 @@ import raisetech.student.management.data.CourseStatus;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
 import raisetech.student.management.domain.CourseDetail;
-import raisetech.student.management.domain.IntegratedDetail;
+import raisetech.student.management.domain.StudentSearchResponse;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.service.StudentService;
 
@@ -102,7 +102,7 @@ class StudentControllerTest {
   @Test
   void 条件に基づいて受講生詳細を検索し正しいデータが返ってくること() throws Exception {
     // モックデータを直接フィールドに設定
-    IntegratedDetail detail = new IntegratedDetail() {
+    StudentSearchResponse response = new StudentSearchResponse() {
       public String name = "テスト花子";
       public String city = "東京";
       public int age = 25;
@@ -114,10 +114,10 @@ class StudentControllerTest {
     // モックサービスの設定
     when(service.searchIntegratedDetails(
         "テスト花子", "テストハナコ", "東京", 25, "女性", "Java", null))
-        .thenReturn(List.of(detail));
+        .thenReturn(List.of(response));
 
     // テストの実行
-    mockMvc.perform(get("/students/search")
+    mockMvc.perform(get("/students")
             .param("name", "テスト花子")
             .param("furigana", "テストハナコ")
             .param("city", "東京")
@@ -130,7 +130,6 @@ class StudentControllerTest {
         .andExpect(jsonPath("$[0].city").value("東京"))
         .andExpect(jsonPath("$[0].age").value(25))
         .andExpect(jsonPath("$[0].gender").value("女性"))
-        .andExpect(jsonPath("$.length()").value(1))  // Corrected the path here
         .andExpect(jsonPath("$[0].courseName").value("Java"));
   }
 

--- a/src/test/java/raisetech/student/management/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/student/management/service/StudentServiceTest.java
@@ -2,7 +2,6 @@ package raisetech.student.management.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -10,21 +9,17 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springdoc.api.OpenApiResourceNotFoundException;
 import raisetech.student.management.controller.converter.CourseConverter;
 import raisetech.student.management.controller.converter.StudentConverter;
 import raisetech.student.management.data.CourseStatus;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
-import raisetech.student.management.domain.IntegratedDetail;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.repository.StudentRepository;
 


### PR DESCRIPTION
第44回の課題のうち「条件を指定して検索する機能」を実装しましたので、レビューをお願いいたします。

# 実装内容
### 条件検索機能の追加
以下の項目を条件として、受講生情報を検索できる機能を実装しました：

- 受講生の名前（部分一致）
- 受講生のフリガナ（部分一致）
- 居住地域（部分一致）
- 年齢（完全一致）
- 性別（完全一致）
- 受講コース（完全一致）
- 申込状況（完全一致）

## DBのテーブル内容

1. students
![スクリーンショット 2024-11-18 223831](https://github.com/user-attachments/assets/85870cdc-71ab-42e3-aaca-3ac8ad9c4c9d)

2. students_courses
![スクリーンショット 2024-11-18 223840](https://github.com/user-attachments/assets/022550e5-3839-4d2b-8cb9-762696396b52)

3. course_status
![スクリーンショット 2024-11-18 223847](https://github.com/user-attachments/assets/20a121de-d13a-42d1-9987-2324e3a701ad)

# 動作確認
### 名前検索
＜部分一致＞　該当する複数の受講生を取得

![スクリーンショット 2024-11-18 224616](https://github.com/user-attachments/assets/190fd714-b9f4-49f3-81b6-7fb564634a38)
![スクリーンショット 2024-11-18 224728](https://github.com/user-attachments/assets/a78bd8a5-72fe-45b0-883d-479b09ef6bfb)
![スクリーンショット 2024-11-18 224743](https://github.com/user-attachments/assets/9eedf526-f14a-43fd-9ade-cf83a55d5e03)

### フリガナ検索

![スクリーンショット 2024-11-18 212157](https://github.com/user-attachments/assets/07a73db3-d7f8-4603-b1ce-1e03b18cafd5)

### 居住地域検索

![スクリーンショット 2024-11-18 225134](https://github.com/user-attachments/assets/95631eb5-1334-4269-a8cb-9f0480602f43)

### 年齢検索

![スクリーンショット 2024-11-18 212309](https://github.com/user-attachments/assets/c2f76f69-a2cc-4cb9-8ed9-b7f7cd53e539)

### 性別検索
※全5件取得できましたが、省略します。
![スクリーンショット 2024-11-18 225430](https://github.com/user-attachments/assets/8a628575-43ec-4b28-95df-30af709105c1)
![スクリーンショット 2024-11-18 225442](https://github.com/user-attachments/assets/2799786c-c5dc-48d7-aba2-240587819e27)

### 複数の条件を組み合わせた検索も可能です
![スクリーンショット 2024-11-18 211913](https://github.com/user-attachments/assets/5c31a6c7-8e4c-43f0-bb71-6ff9355e9ffa)
![スクリーンショット 2024-11-18 212040](https://github.com/user-attachments/assets/caa0b19d-1e82-4926-be81-71e90b1b7bb8)
![スクリーンショット 2024-11-18 212053](https://github.com/user-attachments/assets/7659b791-3e73-487e-a250-d305d777b5fd)
![スクリーンショット 2024-11-18 230550](https://github.com/user-attachments/assets/28bf30fd-d12c-4f1c-826d-f2a7ee53413a)

# テストの結果
![スクリーンショット 2024-11-18 214327](https://github.com/user-attachments/assets/36137c0a-e8e7-4f6e-9368-1ea5aa45e78f)

![スクリーンショット 2024-11-18 231010](https://github.com/user-attachments/assets/125c4d31-4a25-4a16-afcc-9b68ada23af1)


